### PR TITLE
Support 7000-series MetroHotCars tweets.

### DIFF
--- a/dcmetrometrics/hotcars/process_tweets.py
+++ b/dcmetrometrics/hotcars/process_tweets.py
@@ -143,7 +143,8 @@ def tweetIsValidReport(tweet, hotCarData):
                   '3' : (3000, 3289),
                   '4' : (4000, 4099),
                   '5' : (5000, 5191),
-                  '6' : (6000, 6183)
+                  '6' : (6000, 6183),
+                  '7' : (7000, 7747)
                 }
 
     if firstDigit not in carRanges:


### PR DESCRIPTION
Fixes #31, car numbers [from Wikipedia](https://en.wikipedia.org/wiki/Washington_Metro_rolling_stock#7000-series). 

Hopefully, this won’t be used for a while… if the air conditioners on these new things actually work!